### PR TITLE
Add method for zero-padding to multiple of given length

### DIFF
--- a/audiotools/core/audio_signal.py
+++ b/audiotools/core/audio_signal.py
@@ -299,6 +299,14 @@ class AudioSignal(
             self.zero_pad(0, max(length - self.signal_length, 0))
         return self
 
+    def zero_pad_to_multiple(self, length, mode="after"):
+        target_length = math.ceil(self.signal_length / length) * length
+        if mode == "before":
+            self.zero_pad(max(target_length - self.signal_length, 0), 0)
+        elif mode == "after":
+            self.zero_pad(0, max(target_length - self.signal_length, 0))
+        return self
+
     def trim(self, before, after):
         if after == 0:
             self.audio_data = self.audio_data[..., before:]

--- a/tests/core/test_audio_signal.py
+++ b/tests/core/test_audio_signal.py
@@ -318,6 +318,24 @@ def test_trim():
     assert np.allclose(sig1.audio_data, array)
 
 
+def test_zero_pad_to_multiple():
+    array = np.random.randn(4, 2, 16000)
+    sig1 = AudioSignal(array, sample_rate=16000)
+    hop = 256
+
+    sig1.zero_pad_to_multiple(hop, mode="after")
+    assert sig1.signal_length and not sig1.signal_length % hop
+    assert np.allclose(sig1.audio_data[..., :16000], array)
+    assert sig1.audio_data[..., 16000:].abs().sum().item() == 0
+
+    sig1 = AudioSignal(array, sample_rate=16000)
+
+    sig1.zero_pad_to_multiple(hop, mode="before")
+    assert sig1.signal_length and not sig1.signal_length % hop
+    assert np.allclose(sig1.audio_data[..., -16000:], array)
+    assert sig1.audio_data[..., :-16000].abs().sum().item() == 0
+
+
 def test_to_from_ops():
     audio_path = "tests/audio/spk/f10_script4_produced.wav"
     signal = AudioSignal(audio_path)


### PR DESCRIPTION
Proposed method for zero-padding an `AudioSignal` object to the next multiple of a given length in samples.

Also, I appear to be running into an issue with the `black` and `click` versions in the pre-commit hooks, as documented [here](https://github.com/psf/black/issues/2964). One solution would be to upgrade the `black` version in `.pre-commit-config.yaml`.