### PR TITLE
fixed temporary file not being removed

### DIFF
--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -136,6 +136,7 @@ class FFMPEGMixin:
                 command += " -hide_banner -loglevel error"
             subprocess.check_call(shlex.split(command))
             resampled = AudioSignal(f_out)
+            Path.unlink(Path(f.out))
         return resampled
 
     @classmethod


### PR DESCRIPTION
In the ffmpeg resampler the temporary output file from ffmpeg is never deleted. This causes a large storage leak when resampling many files. This PR simply removes the temporary file after it has been loaded into a new `AudioSignal`.