### PR TITLE
Option to use speech-optimized tempo effect in from time_stretch()

### DIFF
--- a/audiotools/core/effects.py
+++ b/audiotools/core/effects.py
@@ -276,7 +276,7 @@ class EffectMixin:
         self.audio_data = self._to_3d(waveform)
         return self.to(device)
 
-    def time_stretch(self, factor: float, quick: bool = True):
+    def time_stretch(self, factor: float, quick: bool = True, speech: bool = True):
         """Time stretch the audio signal.
 
         Parameters
@@ -299,6 +299,9 @@ class EffectMixin:
         ]
         if quick:
             effects[0].insert(1, "-q")
+
+        if speech:
+            effects[0].insert(1, "-s")
 
         waveform = self._to_2d().cpu()
         waveform, sample_rate = torchaudio.sox_effects.apply_effects_tensor(


### PR DESCRIPTION
The SoX `tempo` effect has additional flags `-s` and `-m` which optimize WSOLA parameters for speech and music, respectively. 

In my testing, I found that using the `time_stretch()` without the `-s` flag, there are significant artifacts in the audio, already at 0.7 or 1.3 factors, which are not *too* extreme, in my opinion. Simply adding the `-s` flag makes the output *much more* smoother.

As AudioTools is speech-oriented, I think it would be a sane default for many users to use this flag in time stretch.


Sample below with original, before, after, code was:

```
def stretch(wav)
    a = AudioSignal(wav,sample_rate=24000)
    return a.clone().time_stretch(speed,quick=False).audio_data
```


[0.5_0.7_stretch_samples.zip](https://github.com/descriptinc/audiotools/files/12026404/0.5_0.7_stretch_samples.zip)
