### PR TITLE
Added .min() to support stereo IR rotation.

### DIFF
--- a/audiotools/core/effects.py
+++ b/audiotools/core/effects.py
@@ -96,7 +96,7 @@ class EffectMixin:
             idx = other.audio_data.abs().argmax(axis=-1)
             irs = torch.zeros_like(other.audio_data)
             for i in range(other.batch_size):
-                irs[i] = torch.roll(other.audio_data[i], -idx[i].item(), -1)
+                irs[i] = torch.roll(other.audio_data[i], -idx[i].min().item(), -1)
             other = AudioSignal(irs, other.sample_rate)
 
         delta = torch.zeros_like(other.audio_data)


### PR DESCRIPTION
When using stereo/multi-channel IRs, this error is thrown:
`RuntimeError: a Tensor with 2 elements cannot be converted to Scalar`
This is due to `-idx[i].item()` having multiple entries from the multiple channels.

Adding `.min()` to `-idx[i].min().item()` selects the earliest index of all of the channels to rotate the IR by. This makes it compatible with multi-channel IRs and avoids potentially cutting off parts of the IR.