### PR TITLE
Minor fix to add Mac MPS support

### DIFF
--- a/audiotools/core/loudness.py
+++ b/audiotools/core/loudness.py
@@ -308,6 +308,8 @@ class LoudnessMixin:
         meter = Meter(
             self.sample_rate, filter_class=filter_class, block_size=block_size, **kwargs
         )
+        if "mps" in str(self.audio_data.device):  # MPS has no float64
+            meter = meter.type(torch.float32)
         meter = meter.to(self.device)
         # measure loudness
         loudness = meter.integrated_loudness(self.audio_data.permute(0, 2, 1))


### PR DESCRIPTION
Hi, I was noticing that this code was failing when running on my Mac using the MPS device (the closest thing to CUDA) because MPS has no float64 type implemented.  The fix is just to change to float32 before moving `meter` onto the device.  Because of the "`if`" check,  that conversion will only occur when running on MPS; CUDA and CPU will be unaffected by this change. 