### PR TITLE
[Studio Sound] Ignore start_pts only for mp3 files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ffmpeg
-          sudo apt-get install libsndfile1-dev
+          sudo apt-get install libsndfile1-dev sox libsox-fmt-mp3
           python -m pip install --upgrade pip
           pip install wheel
       - name: Install recent FFMPEG

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ffmpeg
-          sudo apt-get install libsndfile1-dev sox libsox-fmt-mp3
+          sudo apt-get install libsndfile1-dev libsox-dev libsox-fmt-mp3
           python -m pip install --upgrade pip
           pip install wheel
       - name: Install recent FFMPEG

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import shlex
 import subprocess
 import tempfile
@@ -178,13 +179,15 @@ class FFMPEGMixin:
             # in case it's an audio stream starting at some
             # offset in a video container.
             pad = ffprobe_offset(audio_path)
-            # Don't pad files with discrepancies less than
+            file_extension = pathlib.Path(audio_path).suffix.lower()
+            
+            # For mp3s, don't pad files with discrepancies less than
             # 0.027s - it's likely due to codec latency.
             # The amount of latency introduced by mp3 is
             # 1152, which is 0.0261 44khz. So we
             # set the threshold here slightly above that.
             # Source: https://lame.sourceforge.io/tech-FAQ.txt.
-            if pad < 0.027:
+            if file_extension == 'mp3' and pad < 0.027:
                 pad = 0.0
             ff = ffmpy.FFmpeg(
                 inputs={wav_file: None},

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -190,9 +190,6 @@ class FFMPEGMixin:
             # by mp3 is 1152, which is 0.0261 44khz. So we set the threshold
             # here slightly above that.
             # Source: https://lame.sourceforge.io/tech-FAQ.txt.
-            #
-            # The client should match this logic.
-            # See https://linear.app/descript/issue/MEDIA-1034/mp3-files-decoding-incorrectly-during-exportweb-was-echo-during
             if codec == "mp3" and pad < 0.027:
                 pad = 0.0
             ff = ffmpy.FFmpeg(

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -2,6 +2,7 @@ import json
 import shlex
 import subprocess
 import tempfile
+from typing import Tuple
 from pathlib import Path
 
 import ffmpy

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -2,8 +2,8 @@ import json
 import shlex
 import subprocess
 import tempfile
-from typing import Tuple
 from pathlib import Path
+from typing import Tuple
 
 import ffmpy
 import numpy as np
@@ -73,7 +73,7 @@ def ffprobe_offset_and_codec(path: str) -> Tuple[float, str]:
     streams = json.loads(ff.run(stdout=subprocess.PIPE)[0])["streams"]
     seconds_offset = 0.0
     codec = None
-    
+
     # Get the offset and codec of the first audio stream we find
     # and return its start time, if it has one.
     for stream in streams:
@@ -181,19 +181,19 @@ class FFMPEGMixin:
             )
             ff.run()
 
-            # We pad the file using the start time offset in case it's an audio 
+            # We pad the file using the start time offset in case it's an audio
             # stream starting at some offset in a video container.
             pad, codec = ffprobe_offset_and_codec(audio_path)
-            
+
             # For mp3s, don't pad files with discrepancies less than 0.027s -
-            # it's likely due to codec latency. The amount of latency introduced 
-            # by mp3 is 1152, which is 0.0261 44khz. So we set the threshold 
+            # it's likely due to codec latency. The amount of latency introduced
+            # by mp3 is 1152, which is 0.0261 44khz. So we set the threshold
             # here slightly above that.
             # Source: https://lame.sourceforge.io/tech-FAQ.txt.
             #
             # The client should match this logic.
             # See https://linear.app/descript/issue/MEDIA-1034/mp3-files-decoding-incorrectly-during-exportweb-was-echo-during
-            if codec == 'mp3' and pad < 0.027:
+            if codec == "mp3" and pad < 0.027:
                 pad = 0.0
             ff = ffmpy.FFmpeg(
                 inputs={wav_file: None},

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -180,17 +180,18 @@ class FFMPEGMixin:
             )
             ff.run()
 
-            # We pad the file using the start time offset
-            # in case it's an audio stream starting at some
-            # offset in a video container.
+            # We pad the file using the start time offset in case it's an audio 
+            # stream starting at some offset in a video container.
             pad, codec = ffprobe_offset_and_codec(audio_path)
             
-            # For mp3s, don't pad files with discrepancies less than
-            # 0.027s - it's likely due to codec latency.
-            # The amount of latency introduced by mp3 is
-            # 1152, which is 0.0261 44khz. So we
-            # set the threshold here slightly above that.
+            # For mp3s, don't pad files with discrepancies less than 0.027s -
+            # it's likely due to codec latency. The amount of latency introduced 
+            # by mp3 is 1152, which is 0.0261 44khz. So we set the threshold 
+            # here slightly above that.
             # Source: https://lame.sourceforge.io/tech-FAQ.txt.
+            #
+            # The client should match this logic.
+            # See https://linear.app/descript/issue/MEDIA-1034/mp3-files-decoding-incorrectly-during-exportweb-was-echo-during
             if codec == 'mp3' and pad < 0.027:
                 pad = 0.0
             ff = ffmpy.FFmpeg(

--- a/audiotools/core/ffmpeg.py
+++ b/audiotools/core/ffmpeg.py
@@ -61,7 +61,7 @@ def r128stats(filepath: str, quiet: bool):
     return stats_dict
 
 
-def ffprobe_codec_and_offset(path: str) -> Tuple[float, str]:
+def ffprobe_offset_and_codec(path: str) -> Tuple[float, str]:
     """Given a path to a file, returns the start time offset and codec of
     the first audio stream.
     """
@@ -183,7 +183,7 @@ class FFMPEGMixin:
             # We pad the file using the start time offset
             # in case it's an audio stream starting at some
             # offset in a video container.
-            pad, codec = ffprobe_codec_and_offset(audio_path)
+            pad, codec = ffprobe_offset_and_codec(audio_path)
             
             # For mp3s, don't pad files with discrepancies less than
             # 0.027s - it's likely due to codec latency.

--- a/audiotools/core/playback.py
+++ b/audiotools/core/playback.py
@@ -2,8 +2,7 @@
 These are utilities that allow one to embed an AudioSignal
 as a playable object in a Jupyter notebook, or to play audio from
 the terminal, etc.
-"""
-
+"""  # fmt: skip
 import base64
 import io
 import random

--- a/audiotools/core/playback.py
+++ b/audiotools/core/playback.py
@@ -3,6 +3,7 @@ These are utilities that allow one to embed an AudioSignal
 as a playable object in a Jupyter notebook, or to play audio from
 the terminal, etc.
 """
+
 import base64
 import io
 import random

--- a/audiotools/metrics/__init__.py
+++ b/audiotools/metrics/__init__.py
@@ -1,7 +1,6 @@
 """
 Functions for comparing AudioSignal objects to one another.
-"""
-
+"""  # fmt: skip
 from . import distance
 from . import quality
 from . import spectral

--- a/audiotools/metrics/__init__.py
+++ b/audiotools/metrics/__init__.py
@@ -1,6 +1,7 @@
 """
 Functions for comparing AudioSignal objects to one another.
 """
+
 from . import distance
 from . import quality
 from . import spectral

--- a/audiotools/ml/experiment.py
+++ b/audiotools/ml/experiment.py
@@ -1,8 +1,7 @@
 """
 Useful class for Experiment tracking, and ensuring code is
 saved alongside files.
-"""
-
+"""  # fmt: skip
 import datetime
 import os
 import shlex

--- a/audiotools/ml/experiment.py
+++ b/audiotools/ml/experiment.py
@@ -2,6 +2,7 @@
 Useful class for Experiment tracking, and ensuring code is
 saved alongside files.
 """
+
 import datetime
 import os
 import shlex

--- a/examples/abx.py
+++ b/examples/abx.py
@@ -98,6 +98,6 @@ with gr.Blocks() as app:
         fn=build,
         inputs=[user, samples, rating],
         outputs=player.to_list() + [rating, begin, samples, progress],
-    ).then(None, _js=pr.reset_player)
+    ).then(None, js=pr.reset_player)
 
     app.launch()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "ffmpy",
         "ipython",
         "rich",
-        "matplotlib",
+        "matplotlib==3.7", # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
         "librosa",
         "pystoi",
         "torch_stoi",
@@ -65,7 +65,6 @@ setup(
             "pytest-cov",
             "line_profiler",
             "pesq",
-            "matplotlib==3.7", # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
             "gradio==3.32.0",
             "transformers>=4.23.1", 
         ],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "ffmpy",
         "ipython",
         "rich",
-        "matplotlib==3.7", # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
+        "matplotlib==3.7",  # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
         "librosa",
         "pystoi",
         "torch_stoi",
@@ -66,7 +66,7 @@ setup(
             "line_profiler",
             "pesq",
             "gradio==3.32.0",
-            "transformers>=4.23.1", 
+            "transformers>=4.23.1",
         ],
         "docs": [
             "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "ffmpy",
         "ipython",
         "rich",
-        "matplotlib==3.7",  # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
+        "matplotlib==3.5",  # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
         "librosa",
         "pystoi",
         "torch_stoi",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             "pytest-cov",
             "line_profiler",
             "pesq",
-            "gradio==3.41.2",
+            "gradio==3.32.0",
             "transformers>=4.23.1",
         ],
         "docs": [

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,9 @@ setup(
             "pytest-cov",
             "line_profiler",
             "pesq",
+            "matplotlib==3.7", # See https://github.com/librosa/librosa/issues/1763#issuecomment-1742120524
             "gradio==3.32.0",
-            "transformers>=4.23.1",
+            "transformers>=4.23.1", 
         ],
         "docs": [
             "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             "pytest-cov",
             "line_profiler",
             "pesq",
-            "gradio>=3.32.0",
+            "gradio==3.41.2",
             "transformers>=4.23.1",
         ],
         "docs": [

--- a/tests/core/test_grad.py
+++ b/tests/core/test_grad.py
@@ -27,9 +27,15 @@ def test_audio_grad():
                 # If necessary, propagate spectrogram changes to waveform
                 if result.stft_data is not None:
                     result.istft()
-                result.audio_data.sum().backward()
+                if result.audio_data.dtype.is_complex:
+                    result.real().sum().backward()
+                else:
+                    result.audio_data.sum().backward()
             else:
-                result.sum().backward()
+                if result.dtype.is_complex:
+                    result.real.sum().backward()
+                else:
+                    result.sum().backward()
 
             assert signal.audio_data.grad is not None or not target
         except RuntimeError:

--- a/tests/core/test_grad.py
+++ b/tests/core/test_grad.py
@@ -28,12 +28,12 @@ def test_audio_grad():
                 if result.stft_data is not None:
                     result.istft()
                 if result.audio_data.dtype.is_complex:
-                    result.real().sum().backward()
+                    result.audio_data.real().sum().backward()
                 else:
                     result.audio_data.sum().backward()
             else:
                 if result.dtype.is_complex:
-                    result.real.sum().backward()
+                    result.real().sum().backward()
                 else:
                     result.sum().backward()
 

--- a/tests/core/test_grad.py
+++ b/tests/core/test_grad.py
@@ -33,7 +33,7 @@ def test_audio_grad():
                     result.audio_data.sum().backward()
             else:
                 if result.dtype.is_complex:
-                    result.real().sum().backward()
+                    result.real.sum().backward()
                 else:
                     result.sum().backward()
 


### PR DESCRIPTION
From the Linear ticket, it looks like we only should be ignoring start_pts < 0.027 for mp3 files. So let's check for that first