### PR TITLE
[Doc] Incorrect Assignment in STFT Demo Loop

### DIFF
--- a/audiotools/core/audio_signal.py
+++ b/audiotools/core/audio_signal.py
@@ -1158,8 +1158,8 @@ class AudioSignal(
 
         Vary the window and hop length:
 
-        >>> stft_params = [STFTParams(128, 32), STFTParams(512, 128)]
-        >>> for stft_param in stft_params:
+        >>> stft_params_list = [STFTParams(128, 32), STFTParams(512, 128)]
+        >>> for stft_params in stft_params_list:
         >>>     signal.stft_params = stft_params
         >>>     signal.stft()
 


### PR DESCRIPTION
Hi, Thx for your great work!

In the provided STFT (Short-Time Fourier Transform) demo code, there was an error in the loop where the entire stft_params list was being assigned to signal.stft_params instead of the individual stft_param object for each iteration. 