### PR TITLE
Fix deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ exclude_lines =
 universal = 1
 
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
```
descript-audiotools>         Usage of dash-separated 'description-file' will not be supported in future
descript-audiotools>         versions. Please use the underscore name 'description_file' instead.
descript-audiotools> 
descript-audiotools>         By 2026-Mar-03, you need to update your project and remove deprecated calls
descript-audiotools>         or your builds will no longer be supported.
descript-audiotools> 
descript-audiotools>         See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
```